### PR TITLE
add uid support for testing

### DIFF
--- a/src/pages/Authentication/AuthenticationUnlockForm.js
+++ b/src/pages/Authentication/AuthenticationUnlockForm.js
@@ -89,6 +89,7 @@ export default class AuthenticationInit extends React.Component {
           </div>
 
           <Button
+            dataUid='helloivan'
             onClick={this.onUnlock}
             disabled={!submitReady}
             label='Unlock'

--- a/src/ui/Button/Button.js
+++ b/src/ui/Button/Button.js
@@ -11,6 +11,7 @@ export default class Button extends React.PureComponent {
   render() {
     const {
       onClick, label, red, green, blue, gray, className, dataProduct, disabled,
+      dataUid,
     } = this.props
 
     return (
@@ -25,6 +26,7 @@ export default class Button extends React.PureComponent {
           green,
           disabled,
         })}
+        data-uid={dataUid || label}
       >
         {label}
       </button>


### PR DESCRIPTION
will default to "label" prop when no `dataUid` prop is set.